### PR TITLE
Output all the working options and their value at the debug verbose level (-verbose 3)

### DIFF
--- a/params.cpp
+++ b/params.cpp
@@ -247,7 +247,32 @@ bool Params::parseParams(const QStringList &paramsArray) {
         }
     }
 
+    printWorkingOptions();
+
     return true;
+}
+
+void Params::printWorkingOptions() {
+    QuasarAppUtils::Params::log("--- Working options table start ---",
+                                QuasarAppUtils::Debug);
+
+    QVariantMap::const_iterator iter = params.constBegin();
+    while (iter != params.constEnd()) {
+
+        QString row = QString{"Option[%0]"}.arg(iter.key());
+
+        QString value = iter.value().toString();
+        if (!value.isEmpty()) {
+            row += QString{": %1"}.arg(value);
+        }
+
+        QuasarAppUtils::Params::log(row, QuasarAppUtils::Debug);
+
+        ++iter;
+    }
+
+    QuasarAppUtils::Params::log("--- Working options table end ---",
+                                QuasarAppUtils::Debug);
 }
 
 QString Params::getStrArg(const QString& key, const QString &def) {

--- a/params.h
+++ b/params.h
@@ -40,6 +40,13 @@ private:
     static std::string lvlToString(VerboseLvl vLvl);
     static bool writeLoginFile(const QString& log, VerboseLvl vLvl = VerboseLvl::Debug);
 
+    /**
+     * @brief Traverse @a params and output its content (all the working
+     *    options) to stdout in the form of option-value groups at the
+     *    debug verbose level (-verbose 3).
+     */
+    static void printWorkingOptions();
+
 public:
     Params() = delete;
 


### PR DESCRIPTION
Improved based on #21 .

<br>

Printing this information may help to check whether the parameters passed in are correct.

Output example 1 (compare with the [old version](https://github.com/QuasarApp/QuasarAppLib/pull/21#issuecomment-782778170)):

```console
> C:\testcqt\cqtdeployer.exe 'a' 'b' 'c' @('d', 'e', 'f') 'g','h' 'i', 'j' 'PowerShell is a mystery' -verbose '3'
Verbose log: --- Working options table start ---
Verbose log: Option[PowerShell is a mystery]
Verbose log: Option[a]
Verbose log: Option[appName]: cqtdeployer.exe
Verbose log: Option[appPath]: C:/testcqt
Verbose log: Option[b]
Verbose log: Option[c]
Verbose log: Option[d]
Verbose log: Option[e]
Verbose log: Option[f]
Verbose log: Option[g,h]
Verbose log: Option[i]
Verbose log: Option[j]
Verbose log: Option[verbose]: 3
Verbose log: --- Working options table end ---
...
```

Output example 2 (more practical):

```console
> C:\testcqt\cqtdeployer.exe -bin C:/CQtDeployer/CQtDeployer/build/release/cqtdeployer.exe clear -qmake C:/Qt/5.15.2/mingw81_64/bin/qmake.exe -targetDir C:/deployedCqt -libDir C:/CQtDeployer -recursiveDepth 4 noTranslations -verbose 3
Verbose log: --- Working options table start ---
Verbose log: Option[appName]: cqtdeployer.exe
Verbose log: Option[appPath]: C:/testcqt
Verbose log: Option[bin]: C:/CQtDeployer/CQtDeployer/build/release/cqtdeployer.exe
Verbose log: Option[clear]
Verbose log: Option[libDir]: C:/CQtDeployer
Verbose log: Option[noTranslations]
Verbose log: Option[qmake]: C:/Qt/5.15.2/mingw81_64/bin/qmake.exe
Verbose log: Option[recursiveDepth]: 4
Verbose log: Option[targetDir]: C:/deployedCqt
Verbose log: Option[verbose]: 3
Verbose log: --- Working options table end ---
...
```
